### PR TITLE
Use same number of points for each of the engines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ build/prepare:
 ## prepare/milvus
 .PHONY: prepare/milvus
 prepare/milvus: build/prepare
-	./bin/prepare -system milvus -host ${MILVUS_HOST} -num-entities 100000
+	./bin/prepare -system milvus -host ${MILVUS_HOST} -num-entities 1000000
 
 ## prepare/weaviate
 .PHONY: prepare/weaviate


### PR DESCRIPTION
Apparently Milvus was storing/querying only 100K data points while others were using 1M